### PR TITLE
Backend Dockerfile 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+.idea
+dist
+connections.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:22-alpine
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+# Copy shared packages
+WORKDIR /usr/src
+COPY packages/types ./packages/types
+
+# Install shared package dependencies
+WORKDIR /usr/src/packages/types
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install
+
+# Copy backend app
+WORKDIR /usr/src/apps/backend
+COPY apps/backend/package*.json ./
+COPY apps/backend/tsconfig.json ./
+COPY apps/backend/src ./src
+COPY apps/backend/prisma ./prisma
+
+# Install backend dependencies
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install
+
+# Build it
+RUN pnpm run build
+
+# Run it
+EXPOSE 8080
+CMD ["pnpm", "run", "serve"]

--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ Dev Setup
 - `pnpm prisma migrate dev`
 - `cd apps/frontend && pnpm run dev`
 - `cd apps/backend && pnpm run dev`
+
+Docker
+
+The `Dockerfile` corresponds to the backend service. Its context is the repo root because of the shared packages. 
+
+To locally build the image and run the container: 
+- `docker image build -t connections:1 -f ./Dockerfile .`
+- `docker run -td -p 8080:8080 connections:1`
+
+For reducing the size of the docker image, I found this utility to be useful: 
+- `du -shc $dir-or-file`

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon --exec ts-node -r tsconfig-paths/register src/index.ts",
     "start": "ts-node -r tsconfig-paths/register src/index.ts",
     "build": "prisma generate && tsc --project tsconfig.json && tsc-alias",
-    "serve": "node -r tsconfig-paths/register dist/apps/backend/src/index.js"
+    "serve": "pnpm ts-node -r tsconfig-paths/register dist/apps/backend/src/index.js"
   },
   "dependencies": {
     "@prisma/client": "^5.19.1",


### PR DESCRIPTION
```
docker image build -t connections:1 -f ./Dockerfile .
docker run -td -p 8080:8080 connections:1
```

The docker image size is around 477mb, with the app / node modules contributing to about 150mb of that. I'll see if I can slim it down (remove unused dependencies, multistage build, etc).  