### PR TITLE
Add Github Action for Pushing Backend Image

### DIFF
--- a/.github/workflows/buildImage.yaml
+++ b/.github/workflows/buildImage.yaml
@@ -1,0 +1,42 @@
+name: 'Build docker image'
+
+# The action will trigger when a new tag is created
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  AWS_REGION: us-east-1
+  IAM_ROLE_ARN: arn:aws:iam::xxxxxxxxxxxx:role/github_actions # TODO: update once corresponding terraform role code is written
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ env.IAM_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: cursive/connections
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_REF_NAME -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker image push -a $ECR_REGISTRY/$ECR_REPOSITORY

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Dev Setup
 - `pnpm install`
 - Create local postgres database, set name to be `connections` and port to `5432` (the default).
 - `createdb connections_test`
+- `export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/connections_test?schema=public"`
 - `pnpm prisma generate`
 - `pnpm prisma migrate dev`
 - `cd apps/frontend && pnpm run dev`

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,49 @@
+## Deployment Guide 
+
+### Sections: 
+1. [Push Image on Tag](#1-push-image-on-tag-)
+2. [Apply Terraform on New Tag](#2-apply-terraform-on-new-tag)
+
+### 1. Push Image on Tag 
+`.github/workflows/buildImage.yaml` is responsible for building and pushing images to an ECR ([Elastic Container Registry](https://aws.amazon.com/ecr/)) `cursive/connections` repo. The action is triggered when a new tag is created in this Github repo. 
+
+The `github_actions` role uses this policy to push to the ECR repo. Once the Terraform + Github Action flow works I will reduce the scope of ecr actions (note it's currently `ecr:*`).
+``` 
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:*",
+                "cloudtrail:LookupEvents"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": [
+                        "replication.ecr.amazonaws.com"
+                    ]
+                }
+            }
+        }
+    ]
+}
+```
+
+### 2. Apply Terraform on New Tag
+
+[Terraform](https://www.terraform.io/) is an IaC (Infra as Code) tool which allows infra (in our case, AWS cloud resources) to be declared explicitly in code and applied directly to our AWS account.
+
+After a tag is created, the service image(s) will be built and pushed to our ECR repo corresponding to the newest version. 
+
+After a successful push, our Terraform code will be applied to our AWS account to update our current resources to using the newest image version. 
+
+One goal I have for the terraform setup is to have a validation step (ideally automated, but realistically probably manual) to check the new version works, and _then and only then_ point the ALB (Amazon Load Balancer) to the new version from the old version. At that point we can either destroy the old version or keep it around in the event we need to failover. This goal is the main "known unknown" in the Terraform setup at this point. 


### PR DESCRIPTION
This is currently unused. The next PR will be the terraform code to apply the correct the IAM roles, which will then be used in the GH action to push images to ECR. 