### PR TITLE
Add Terraform Code for Docker Image Github Action

### DIFF
--- a/deployment/.gitignore
+++ b/deployment/.gitignore
@@ -1,0 +1,35 @@
+# Local .terraform directories
+**/.terraform/*
+**/.terraform.*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,49 +1,156 @@
-## Deployment Guide 
+## Deployment Guide
 
-### Sections: 
-1. [Push Image on Tag](#1-push-image-on-tag-)
-2. [Apply Terraform on New Tag](#2-apply-terraform-on-new-tag)
+### Sections:
+- [Infra Phases](#infra-phases)
+- [Phase 1: Creating / Destroying Infra](#phase-1-creating--destroying-infra)
+- [Phase 2: Updating Infra](#phase-2-updating-infra-)
+- [Push Image on New Tag](#push-image-on-new-tag-)
+- [Apply Terraform on New Tag](#apply-terraform-on-new-tag)
 
-### 1. Push Image on Tag 
-`.github/workflows/buildImage.yaml` is responsible for building and pushing images to an ECR ([Elastic Container Registry](https://aws.amazon.com/ecr/)) `cursive/connections` repo. The action is triggered when a new tag is created in this Github repo. 
+### Appendix: 
+- [Dependency Installation](#dependency-installation-)
+- [Manually Create and Apply Admin User](#manually-create-and-apply-admin-user)
+- [Creating a New Tag](#creating-a-new-tag)
+- [Manually Push Tag to ECR](#manually-push-tag-to-ecr-)
+- [Deployment TODOs](#todo)
 
-The `github_actions` role uses this policy to push to the ECR repo. Once the Terraform + Github Action flow works I will reduce the scope of ecr actions (note it's currently `ecr:*`).
+### Infra Phases
+
+There are two distinct phases for infra.
+
+The first phase is infra creation / destruction. This phase is manual.
+
+The second phase is delegating permission for updating the infra. Github Actions will be used for [building and pushing images to ECR](#push-image-on-tag) and [applying terraform on the infra to use the latest image](#apply-terraform-on-new-tag). 
+
+### Phase 1: Creating / Destroying Infra
+
+Given the risky / high-stakes nature of creating and destroying infra it will be a manual operation that requires developer action. 
+
+For instructions for local setup go to [Set Up Admin Profile](#set-up-admin-profile-).
+
+The admin will need to be created manually the first time. For instructions refer to [Manually Create Admin Role](#manually-create-admin-role-).
+
+Once set up, the only other step is to uncomment two lines in the [`provider.tf`](provider.tf) related to terraform using local credentials. 
+
+To create the infra, run these commands: 
 ``` 
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ecr:*",
-                "cloudtrail:LookupEvents"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreateServiceLinkedRole"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "StringEquals": {
-                    "iam:AWSServiceName": [
-                        "replication.ecr.amazonaws.com"
-                    ]
-                }
-            }
-        }
-    ]
-}
+terraform init
+terraform plan
+terraform apply
 ```
 
-### 2. Apply Terraform on New Tag
+Following `apply` keep note of the output roles arns, these will be needed for the next step.
+
+And to destroy resources: 
+``` 
+terraform destroy
+```
+
+### Phase 2: Updating Infra 
+
+Given the repeated nature of updating, it's important to have a streamlined, automated, and tightly scoped process for updating our infra. 
+
+The prior creation step (`terraform apply`) will create the roles required for this step. 
+
+Once these arns are added to the Github Actions in `.github/workflows` the actions do the rest. 
+
+The only developer action required will be to [create a new tag](#creating-a-new-tag) in this github repo. 
+
+### Push Image on New Tag
+`.github/workflows/buildImage.yaml` is responsible for building and pushing images to an ECR ([Elastic Container Registry](https://aws.amazon.com/ecr/)) repo. The action is triggered when a new tag is created in this Github repo.
+
+### Apply Terraform on New Tag
 
 [Terraform](https://www.terraform.io/) is an IaC (Infra as Code) tool which allows infra (in our case, AWS cloud resources) to be declared explicitly in code and applied directly to our AWS account.
 
-After a tag is created, the service image(s) will be built and pushed to our ECR repo corresponding to the newest version. 
+After a tag is created, the service image(s) will be built and pushed to our ECR repo corresponding to the newest version.
 
-After a successful push, our Terraform code will be applied to our AWS account to update our current resources to using the newest image version. 
+After a successful push, our Terraform code will be applied to our AWS account to update our current resources to using the newest image version.
 
-One goal I have for the terraform setup is to have a validation step (ideally automated, but realistically probably manual) to check the new version works, and _then and only then_ point the ALB (Amazon Load Balancer) to the new version from the old version. At that point we can either destroy the old version or keep it around in the event we need to failover. This goal is the main "known unknown" in the Terraform setup at this point. 
+One goal I have for the terraform setup is to have a validation step (ideally automated, but realistically probably manual) to check the new version works, and _then and only then_ point the ALB (Amazon Load Balancer) to the new version from the old version. At that point we can either destroy the old version or keep it around in the event we need to failover. This goal is the main "known unknown" in the Terraform setup at this point.
+
+## Appendix
+
+### Dependency Installation 
+
+Install terraform:
+``` 
+brew tap hashicorp/tap
+brew install hashicorp/tap/terraform
+```
+
+Install docker:
+``` 
+brew install --cask docker
+```
+
+### Manually Create and Apply Admin User
+
+Create User: 
+- Navigate to IAM Users
+- Select `Create user`.
+- Set name (e.g. `connections-admin`) and click next.
+- Select `Attach policies directly` and attach `AdministratorAccess` and click next. 
+- `Create user`.
+
+Create Key Pair for User:
+- Navigate to user details.
+- Select `Create access key` in upper right. 
+- Select `Command Line Interface (CLI)` and click next.
+- `Create access key`.
+- Record values, going to need them in the next step. 
+
+Create Local Profile for User: 
+- `brew install awscli`
+- `aws configure --profile connections-admin`
+- Provide AWS Access Key ID from last section.
+- Provide AWS Secret Access Key from last section. 
+- Provide default region name: `ap-southeast-1` (Singapore).
+
+
+### Creating and Running Docker Image 
+``` 
+docker image build -t connections:1 -f ./Dockerfile .
+```
+
+Run on port 8080:
+``` 
+docker run -td -p 8080:8080 connections:1
+```
+
+### Manually Push Tag to ECR 
+
+``` 
+export ACCOUNT_NUMBER="${AWS account number}"
+export AWS_REGION="ap-southeast-1"
+export ECR_REPO_NAME=${Repo name} 
+export $IMAGE-ID=${Image ID from docker image build}
+
+aws ecr get-login-password --profile connections-admin-role --region $AWS_REGION 
+
+docker login --username AWS --password-stdin $ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com 
+
+docker tag $IMAGE-ID $ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO_NAME:1`
+docker push $ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO_NAME:1`
+```
+
+### TODO
+- [ ] Make a Github Secret for generated role.
+- [ ] Add networking and ECS resources to terraform code.
+- [ ] Add Github Action to run `terraform apply` on latest tag.
+- [ ] Create rollback command, some way of rolling back to last healthy version.
+- [ ] Have some manual testing step, ie running `apply` creates newest version but the ALB won't point to it until it's been manually validated.
+- [ ] Figure out how to fully manage AWS resources so terraform can also destroy them.
+- [ ] Minimize scope of github action policy.
+- [ ] swap to AWS CLI V2 (https://aws.amazon.com/cli/)
+
+Terraform resources for next step: 
+- The VPC (virtual private cloud) that holds our subnet
+- The subnet within the VPC that holds our ECS container(s)
+- The Route Table that configures routing for the subnet
+- The Internet Gateway to make our resources available to the internet at specific IP addresses
+- ECS that's running the backend container
+- Security Groups (like a firewall) to manage access
+
+resources:
+- https://harrisoncramer.me/setting-up-docker-with-terraform-and-ec2/

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -1,0 +1,69 @@
+module "ecr" {
+  source  = "cloudposse/ecr/aws"
+  version = "0.35.0"
+
+
+  namespace = var.namespace
+  # stage     = var.stage
+  name      = var.name
+
+  max_image_count         = 100
+  protected_tags          = ["latest"]
+  image_tag_mutability    = "MUTABLE"
+  enable_lifecycle_policy = true
+
+  # Whether to delete the repository even if it contains images
+  force_delete = true
+}
+
+resource "aws_iam_openid_connect_provider" "github_actions_oidc" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1"
+  ]
+
+  tags = {
+    Namespace = var.namespace
+    # Stage     = var.stage
+    Name      = var.name
+  }
+}
+
+resource "aws_iam_role" "github_actions_role" {
+  name = "github_actions"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_actions_oidc.arn
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" : "repo:${var.namespace}-${var.name}:*"
+          },
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  # TODO: once it works, minimize scope
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+
+  tags = {
+    Namespace = var.namespace
+    # Stage     = var.stage
+    Name      = var.name
+  }
+}

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -1,0 +1,4 @@
+output "github_actions_role_arn" {
+  description = "The ARN of the role to be assumed by the GitHub Actions"
+  value       = aws_iam_role.github_actions_role.arn
+}

--- a/deployment/provider.tf
+++ b/deployment/provider.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region     = "${var.aws_region}"
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+    }
+  }
+
+  # For creating / destroying infra with Admin profile
+  # shared_credentials_files = ["~/.aws/credentials"]
+  # profile = "connections-admin"
+}

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  type        = string
+  default     = "ap-southeast-1" // Singapore
+  description = "aws region for current resource"
+}
+
+variable "aws_account_number" {
+  type        = string
+  description = "AWS account number"
+}
+
+variable "namespace" {
+  type        = string
+  default     = "cursive"
+  description = "Usually an abbreviation of your organization name, e.g. 'eg' or 'cp'"
+}
+
+variable "name" {
+  type        = string
+  default     = "connections"
+  description = "Project name"
+}
+
+# If we decide to have a staging vs production environment this will be relevant.
+variable "stage" {
+  type        = string
+  default     = "prod"
+  description = "Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}


### PR DESCRIPTION
This adds the terraform code needed to create the ECR repo, github action role, and OIDC provider (for allowing the Action to assume the role). 

I've applied this to my personal account and get the correct resources. As soon as it's merged I'll apply it to our infra.  