### PR TITLE
Support Toast 

### DIFF
--- a/apps/frontend/src/components/ui/SupportToast.tsx
+++ b/apps/frontend/src/components/ui/SupportToast.tsx
@@ -1,39 +1,47 @@
 import Link from "next/link";
-import {logClientEvent} from "@/lib/frontend/metrics";
+import { logClientEvent } from "@/lib/frontend/metrics";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const SupportToast = ( className: string, isError: boolean, toastMessage: string, messageTarget: string, errorInfo: string): any => {
-
+export const SupportToast = (
+  className: string,
+  isError: boolean,
+  toastMessage: string,
+  messageTarget: string,
+  errorInfo: string
+) => {
   const params = `text=Toast msg: ${toastMessage};\nError info: ${errorInfo};`;
   const msg = encodeURI(`${messageTarget}?${params}`);
   return (
     <span className={className}>
-
-      <div style={{display: "ruby"}}>
-      {isError &&
-          <svg style={{marginRight: "6px"}} xmlns="https://www.w3.org/2000/svg"
-               viewBox="0 0 20 20"
-               fill="currentColor" height="20" width="20">
-              <path
-                  fillRule="evenodd"
-                  d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
-                  clipRule="evenodd"
-              />
-          </svg>}
-
-        {`${toastMessage}   `}
-
+      <div style={{ display: "ruby" }}>
+        {isError && (
+          <svg
+            style={{ marginRight: "6px" }}
+            xmlns="https://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            height="20"
+            width="20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
+              clipRule="evenodd"
+            />
+          </svg>
+        )}
+        {`${toastMessage}${toastMessage.endsWith(".") ? "" : "."} `}
         <Link
           href={msg}
           // Open link in new tab -- turns out this is pretty important, without it errors occur in tg link
           target="_blank"
           className="underline font-bold"
           onClick={() => {
-            logClientEvent("error-support-link-clicked", {})
+            logClientEvent("error-support-link-clicked", {});
           }}
         >
-        Click for support
-      </Link>
+          Send this error to our team for support here
+        </Link>
+        .
       </div>
     </span>
   );

--- a/apps/frontend/src/components/ui/SupportToast.tsx
+++ b/apps/frontend/src/components/ui/SupportToast.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import {logClientEvent} from "@/lib/frontend/metrics";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const SupportToast = ( className: string, isError: boolean, toastMessage: string, messageTarget: string, errorInfo: string): any => {
@@ -30,6 +31,7 @@ export const SupportToast = ( className: string, isError: boolean, toastMessage:
         // Open link in new tab -- turns out this is pretty important, without it errors occur in tg link
         target="_blank"
         className="underline font-bold"
+        onClick={() => {logClientEvent("error-support-link-clicked", {})}}
       >
         Click for support
       </Link>

--- a/apps/frontend/src/components/ui/SupportToast.tsx
+++ b/apps/frontend/src/components/ui/SupportToast.tsx
@@ -7,34 +7,34 @@ export const SupportToast = ( className: string, isError: boolean, toastMessage:
   const params = `text=Toast msg: ${toastMessage};\nError info: ${errorInfo};`;
   const msg = encodeURI(`${messageTarget}?${params}`);
   return (
-    <span
-      className={className}>
+    <span className={className}>
 
-        {isError &&
-            <svg style={{display: "inline-block", marginRight: "6px"}} xmlns="https://www.w3.org/2000/svg" viewBox="0 0 20 20"
-                         fill="currentColor" height="20" width="20">
-            <path
-                fillRule="evenodd"
-                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
-                clipRule="evenodd"
-            />
-        </svg>}
+      <div style={{display: "ruby"}}>
+      {isError &&
+          <svg style={{marginRight: "6px"}} xmlns="https://www.w3.org/2000/svg"
+               viewBox="0 0 20 20"
+               fill="currentColor" height="20" width="20">
+              <path
+                  fillRule="evenodd"
+                  d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
+                  clipRule="evenodd"
+              />
+          </svg>}
 
-      <div style={{display: "inline-block"}}>
-        {toastMessage}
-      </div>
+        {`${toastMessage}   `}
 
-      <br/>
-
-      <Link
-        href={msg}
-        // Open link in new tab -- turns out this is pretty important, without it errors occur in tg link
-        target="_blank"
-        className="underline font-bold"
-        onClick={() => {logClientEvent("error-support-link-clicked", {})}}
-      >
+        <Link
+          href={msg}
+          // Open link in new tab -- turns out this is pretty important, without it errors occur in tg link
+          target="_blank"
+          className="underline font-bold"
+          onClick={() => {
+            logClientEvent("error-support-link-clicked", {})
+          }}
+        >
         Click for support
       </Link>
+      </div>
     </span>
   );
 };

--- a/apps/frontend/src/components/ui/SupportToast.tsx
+++ b/apps/frontend/src/components/ui/SupportToast.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const SupportToast = ( className: string, isError: boolean, toastMessage: string, messageTarget: string, errorInfo: string): any => {
+
+  const params = `text=Toast msg: ${toastMessage};\nError info: ${errorInfo};`;
+  const msg = encodeURI(`${messageTarget}?${params}`);
+  return (
+    <span
+      className={className}>
+
+        {isError &&
+            <svg style={{display: "inline-block", marginRight: "6px"}} xmlns="https://www.w3.org/2000/svg" viewBox="0 0 20 20"
+                         fill="currentColor" height="20" width="20">
+            <path
+                fillRule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
+                clipRule="evenodd"
+            />
+        </svg>}
+
+      <div style={{display: "inline-block"}}>
+        {toastMessage}
+      </div>
+
+      <br/>
+
+      <Link
+        href={msg}
+        // Open link in new tab -- turns out this is pretty important, without it errors occur in tg link
+        target="_blank"
+        className="underline font-bold"
+      >
+        Click for support
+      </Link>
+    </span>
+  );
+};

--- a/apps/frontend/src/constants.ts
+++ b/apps/frontend/src/constants.ts
@@ -11,3 +11,5 @@ export const communitiesHumanReadable: { [key: string]: string } = {
   devcon: "Dev Con 2014",
   testing: "Testing",
 };
+
+export const ERROR_SUPPORT_CONTACT = "https://t.me/stevenelleman"

--- a/apps/frontend/src/features/login/EnterCode.tsx
+++ b/apps/frontend/src/features/login/EnterCode.tsx
@@ -4,7 +4,8 @@ import { toast } from "sonner";
 import { RegisterHeader } from "@/features/register/RegisterHeader";
 import { AppButton } from "@/components/ui/Button";
 import { AppCopy } from "@/components/ui/AppCopy";
-import {SupportToast} from "@/components/ui/SupportToast";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 interface EnterCodeProps {
   email: string;
@@ -22,7 +23,7 @@ const EnterCode: React.FC<EnterCodeProps> = ({ email, submitCode }) => {
       await submitCode(normalizedCode);
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "Please enter a valid 6-digit code", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Please enter a valid 6-digit code", ERROR_SUPPORT_CONTACT, errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/features/login/EnterCode.tsx
+++ b/apps/frontend/src/features/login/EnterCode.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
-import { SigninTokenSchema } from "@types";
+import {errorToString, SigninTokenSchema} from "@types";
 import { toast } from "sonner";
 import { RegisterHeader } from "@/features/register/RegisterHeader";
 import { AppButton } from "@/components/ui/Button";
 import { AppCopy } from "@/components/ui/AppCopy";
+import {SupportToast} from "@/components/ui/SupportToast";
 
 interface EnterCodeProps {
   email: string;
@@ -21,7 +22,7 @@ const EnterCode: React.FC<EnterCodeProps> = ({ email, submitCode }) => {
       await submitCode(normalizedCode);
     } catch (error) {
       console.error(error);
-      toast.error("Please enter a valid 6-digit code");
+      toast(SupportToast("", true, "Please enter a valid 6-digit code", "https://t.me/stevenelleman", errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/features/login/EnterEmail.tsx
+++ b/apps/frontend/src/features/login/EnterEmail.tsx
@@ -5,7 +5,8 @@ import { AppButton } from "@/components/ui/Button";
 import { AppInput } from "@/components/ui/AppInput";
 import { RegisterHeader } from "@/features/register/RegisterHeader";
 import { AppCopy } from "@/components/ui/AppCopy";
-import {SupportToast} from "@/components/ui/SupportToast";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 interface EnterEmailProps {
   submitEmail: (email: string) => Promise<void>;
@@ -24,7 +25,7 @@ const EnterEmail: React.FC<EnterEmailProps> = ({ submitEmail }) => {
       setLoading(false);
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "Please enter a valid email address", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Please enter a valid email address", ERROR_SUPPORT_CONTACT, errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/features/login/EnterEmail.tsx
+++ b/apps/frontend/src/features/login/EnterEmail.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
-import { EmailSchema } from "@types";
+import {EmailSchema, errorToString} from "@types";
 import { toast } from "sonner";
 import { AppButton } from "@/components/ui/Button";
 import { AppInput } from "@/components/ui/AppInput";
 import { RegisterHeader } from "@/features/register/RegisterHeader";
 import { AppCopy } from "@/components/ui/AppCopy";
+import {SupportToast} from "@/components/ui/SupportToast";
 
 interface EnterEmailProps {
   submitEmail: (email: string) => Promise<void>;
@@ -23,7 +24,7 @@ const EnterEmail: React.FC<EnterEmailProps> = ({ submitEmail }) => {
       setLoading(false);
     } catch (error) {
       console.error(error);
-      toast.error("Please enter a valid email address");
+      toast(SupportToast("", true, "Please enter a valid email address", "https://t.me/stevenelleman", errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/features/login/LoginWithPasskey.tsx
+++ b/apps/frontend/src/features/login/LoginWithPasskey.tsx
@@ -5,8 +5,9 @@ import { generateAuthenticationOptions } from "@simplewebauthn/server";
 import { AppButton } from "@/components/ui/Button";
 import { RegisterHeader } from "@/features/register/RegisterHeader";
 import { AppCopy } from "@/components/ui/AppCopy";
-import {SupportToast} from "@/components/ui/SupportToast";
-import {errorToString} from "@types";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { errorToString } from "@types";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 interface LoginWithPasskeyProps {
   onPasskeyLogin: (password: string) => Promise<void>;
@@ -26,7 +27,7 @@ const LoginWithPasskey: React.FC<LoginWithPasskeyProps> = ({
       await onPasskeyLogin(id);
     } catch (error) {
       console.error("Error logging in: ", error);
-      toast(SupportToast("", true, "Authentication failed! Please try again", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Authentication failed! Please try again", ERROR_SUPPORT_CONTACT, errorToString(error)));
       return;
     }
   };

--- a/apps/frontend/src/features/login/LoginWithPasskey.tsx
+++ b/apps/frontend/src/features/login/LoginWithPasskey.tsx
@@ -5,6 +5,8 @@ import { generateAuthenticationOptions } from "@simplewebauthn/server";
 import { AppButton } from "@/components/ui/Button";
 import { RegisterHeader } from "@/features/register/RegisterHeader";
 import { AppCopy } from "@/components/ui/AppCopy";
+import {SupportToast} from "@/components/ui/SupportToast";
+import {errorToString} from "@types";
 
 interface LoginWithPasskeyProps {
   onPasskeyLogin: (password: string) => Promise<void>;
@@ -24,7 +26,7 @@ const LoginWithPasskey: React.FC<LoginWithPasskeyProps> = ({
       await onPasskeyLogin(id);
     } catch (error) {
       console.error("Error logging in: ", error);
-      toast.error("Authentication failed! Please try again.");
+      toast(SupportToast("", true, "Authentication failed! Please try again", "https://t.me/stevenelleman", errorToString(error)));
       return;
     }
   };

--- a/apps/frontend/src/features/register/EnterCode.tsx
+++ b/apps/frontend/src/features/register/EnterCode.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
-import { SigninTokenSchema } from "@types";
+import {errorToString, SigninTokenSchema} from "@types";
 import { toast } from "sonner";
 import { RegisterHeader } from "./RegisterHeader";
 import { AppButton } from "@/components/ui/Button";
 import { AppCopy } from "@/components/ui/AppCopy";
+import {SupportToast} from "@/components/ui/SupportToast";
 
 interface EnterCodeProps {
   email: string;
@@ -21,7 +22,7 @@ const EnterCode: React.FC<EnterCodeProps> = ({ email, submitCode }) => {
       await submitCode(normalizedCode);
     } catch (error) {
       console.error(error);
-      toast.error("Please enter a valid 6-digit code");
+      toast(SupportToast("", true, "Please enter a valid 6-digit code", "https://t.me/stevenelleman", errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/features/register/EnterCode.tsx
+++ b/apps/frontend/src/features/register/EnterCode.tsx
@@ -4,7 +4,8 @@ import { toast } from "sonner";
 import { RegisterHeader } from "./RegisterHeader";
 import { AppButton } from "@/components/ui/Button";
 import { AppCopy } from "@/components/ui/AppCopy";
-import {SupportToast} from "@/components/ui/SupportToast";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 interface EnterCodeProps {
   email: string;
@@ -22,7 +23,7 @@ const EnterCode: React.FC<EnterCodeProps> = ({ email, submitCode }) => {
       await submitCode(normalizedCode);
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "Please enter a valid 6-digit code", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Please enter a valid 6-digit code", ERROR_SUPPORT_CONTACT, errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/features/register/EnterEmail.tsx
+++ b/apps/frontend/src/features/register/EnterEmail.tsx
@@ -5,7 +5,8 @@ import { AppButton } from "@/components/ui/Button";
 import { AppInput } from "@/components/ui/AppInput";
 import { RegisterHeader } from "./RegisterHeader";
 import { AppCopy } from "@/components/ui/AppCopy";
-import {SupportToast} from "@/components/ui/SupportToast";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 interface EnterEmailProps {
   submitEmail: (email: string) => Promise<void>;
@@ -28,7 +29,7 @@ const EnterEmail: React.FC<EnterEmailProps> = ({
       setLoading(false);
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "Please enter a valid email address", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Please enter a valid email address", ERROR_SUPPORT_CONTACT, errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/features/register/EnterEmail.tsx
+++ b/apps/frontend/src/features/register/EnterEmail.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
-import { EmailSchema } from "@types";
+import {EmailSchema, errorToString} from "@types";
 import { toast } from "sonner";
 import { AppButton } from "@/components/ui/Button";
 import { AppInput } from "@/components/ui/AppInput";
 import { RegisterHeader } from "./RegisterHeader";
 import { AppCopy } from "@/components/ui/AppCopy";
+import {SupportToast} from "@/components/ui/SupportToast";
 
 interface EnterEmailProps {
   submitEmail: (email: string) => Promise<void>;
@@ -27,7 +28,7 @@ const EnterEmail: React.FC<EnterEmailProps> = ({
       setLoading(false);
     } catch (error) {
       console.error(error);
-      toast.error("Please enter a valid email address");
+      toast(SupportToast("", true, "Please enter a valid email address", "https://t.me/stevenelleman", errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/features/register/EnterUserInfo.tsx
+++ b/apps/frontend/src/features/register/EnterUserInfo.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import {errorToString, UsernameSchema} from "@types";
+import { errorToString, UsernameSchema } from "@types";
 import { verifyUsernameIsUnique } from "@/lib/auth/util";
 import { toast } from "sonner";
 import { MdKeyboardArrowRight as ArrowRightIcon } from "react-icons/md";
@@ -9,7 +9,8 @@ import { IoCloseSharp as CloseIcon } from "react-icons/io5";
 import useSettings from "@/hooks/useSettings";
 import { AppButton } from "@/components/ui/Button";
 import { Icons } from "@/components/Icons";
-import {SupportToast} from "@/components/ui/SupportToast";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 interface FormData {
   username: string;
@@ -122,7 +123,7 @@ const EnterUserInfo: React.FC<EnterUserInfoProps> = ({
       });
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "An error occurred while submitting the form", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "An error occurred while submitting the form", ERROR_SUPPORT_CONTACT, errorToString(error)));
     }
   };
 
@@ -138,7 +139,7 @@ const EnterUserInfo: React.FC<EnterUserInfoProps> = ({
         }
       } catch (error) {
         console.error(error);
-        toast(SupportToast("", true, "Username must be alphanumeric and between 3-20 characters", "https://t.me/stevenelleman", errorToString(error)));
+        toast(SupportToast("", true, "Username must be alphanumeric and between 3-20 characters", ERROR_SUPPORT_CONTACT, errorToString(error)));
         return;
       }
     } else if (step === 2 || step === 3) {

--- a/apps/frontend/src/features/register/EnterUserInfo.tsx
+++ b/apps/frontend/src/features/register/EnterUserInfo.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { UsernameSchema } from "@types";
+import {errorToString, UsernameSchema} from "@types";
 import { verifyUsernameIsUnique } from "@/lib/auth/util";
 import { toast } from "sonner";
 import { MdKeyboardArrowRight as ArrowRightIcon } from "react-icons/md";
@@ -9,6 +9,7 @@ import { IoCloseSharp as CloseIcon } from "react-icons/io5";
 import useSettings from "@/hooks/useSettings";
 import { AppButton } from "@/components/ui/Button";
 import { Icons } from "@/components/Icons";
+import {SupportToast} from "@/components/ui/SupportToast";
 
 interface FormData {
   username: string;
@@ -121,7 +122,7 @@ const EnterUserInfo: React.FC<EnterUserInfoProps> = ({
       });
     } catch (error) {
       console.error(error);
-      toast.error("An error occurred while submitting the form");
+      toast(SupportToast("", true, "An error occurred while submitting the form", "https://t.me/stevenelleman", errorToString(error)));
     }
   };
 
@@ -137,9 +138,7 @@ const EnterUserInfo: React.FC<EnterUserInfoProps> = ({
         }
       } catch (error) {
         console.error(error);
-        toast.error(
-          "Username must be alphanumeric and between 3-20 characters"
-        );
+        toast(SupportToast("", true, "Username must be alphanumeric and between 3-20 characters", "https://t.me/stevenelleman", errorToString(error)));
         return;
       }
     } else if (step === 2 || step === 3) {

--- a/apps/frontend/src/features/register/RegisterWithPasskey.tsx
+++ b/apps/frontend/src/features/register/RegisterWithPasskey.tsx
@@ -5,8 +5,9 @@ import { generateRegistrationOptions } from "@simplewebauthn/server";
 import { AppButton } from "@/components/ui/Button";
 import { RegisterHeader } from "./RegisterHeader";
 import { AppCopy } from "@/components/ui/AppCopy";
-import {SupportToast} from "@/components/ui/SupportToast";
-import {errorToString} from "@types";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { errorToString } from "@types";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 interface RegisterWithPasskeyProps {
   username: string;
@@ -40,7 +41,7 @@ const RegisterWithPasskey: React.FC<RegisterWithPasskeyProps> = ({
       await onPasskeyRegister(id, authPublicKey);
     } catch (error) {
       console.error("Error creating account: ", error);
-      toast(SupportToast("", true, "Authentication failed! Please try again.", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Authentication failed! Please try again.", ERROR_SUPPORT_CONTACT, errorToString(error)));
       return;
     }
   };

--- a/apps/frontend/src/features/register/RegisterWithPasskey.tsx
+++ b/apps/frontend/src/features/register/RegisterWithPasskey.tsx
@@ -5,6 +5,8 @@ import { generateRegistrationOptions } from "@simplewebauthn/server";
 import { AppButton } from "@/components/ui/Button";
 import { RegisterHeader } from "./RegisterHeader";
 import { AppCopy } from "@/components/ui/AppCopy";
+import {SupportToast} from "@/components/ui/SupportToast";
+import {errorToString} from "@types";
 
 interface RegisterWithPasskeyProps {
   username: string;
@@ -38,7 +40,7 @@ const RegisterWithPasskey: React.FC<RegisterWithPasskeyProps> = ({
       await onPasskeyRegister(id, authPublicKey);
     } catch (error) {
       console.error("Error creating account: ", error);
-      toast.error("Authentication failed! Please try again.");
+      toast(SupportToast("", true, "Authentication failed! Please try again.", "https://t.me/stevenelleman", errorToString(error)));
       return;
     }
   };

--- a/apps/frontend/src/pages/login.tsx
+++ b/apps/frontend/src/pages/login.tsx
@@ -106,7 +106,7 @@ const LoginPage: React.FC = () => {
       router.push("/profile");
     } catch (error) {
       console.error("Passkey authentication error:", error);
-      toast(SupportToast("", true, "Passkey authentication failed. Please try again", ERROR_SUPPORT_CONTACT, errorToString(error)));
+      toast(SupportToast("", true, "Passkey authentication failed. Please try password instead", ERROR_SUPPORT_CONTACT, errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/pages/login.tsx
+++ b/apps/frontend/src/pages/login.tsx
@@ -52,7 +52,15 @@ const LoginPage: React.FC = () => {
       await requestSigninToken(submittedEmail);
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "Error requesting signin token", ERROR_SUPPORT_CONTACT, errorToString(error)));
+      toast(
+        SupportToast(
+          "",
+          true,
+          "Error requesting signin token",
+          ERROR_SUPPORT_CONTACT,
+          errorToString(error)
+        )
+      );
       return;
     }
 
@@ -89,7 +97,15 @@ const LoginPage: React.FC = () => {
       router.push("/profile");
     } catch (error) {
       console.error("Password authentication error:", error);
-      toast.error("Invalid password. Please try again.");
+      toast(
+        SupportToast(
+          "",
+          true,
+          "Invalid password. Please try again",
+          ERROR_SUPPORT_CONTACT,
+          errorToString(error)
+        )
+      );
     }
   };
 
@@ -106,7 +122,15 @@ const LoginPage: React.FC = () => {
       router.push("/profile");
     } catch (error) {
       console.error("Passkey authentication error:", error);
-      toast(SupportToast("", true, "Passkey authentication failed. Please try password instead", ERROR_SUPPORT_CONTACT, errorToString(error)));
+      toast(
+        SupportToast(
+          "",
+          true,
+          "Passkey authentication failed",
+          ERROR_SUPPORT_CONTACT,
+          errorToString(error)
+        )
+      );
     }
   };
 

--- a/apps/frontend/src/pages/login.tsx
+++ b/apps/frontend/src/pages/login.tsx
@@ -12,10 +12,11 @@ import {
 } from "@/lib/auth";
 import { HeaderCover } from "@/components/ui/HeaderCover";
 import useSettings from "@/hooks/useSettings";
-import {errorToString, UserLoginResponse} from "@types";
+import { errorToString, UserLoginResponse } from "@types";
 import { storage } from "@/lib/storage";
 import { logClientEvent } from "@/lib/frontend/metrics";
-import {SupportToast} from "@/components/ui/SupportToast";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 enum LoginState {
   EMAIL = "email",
@@ -51,7 +52,7 @@ const LoginPage: React.FC = () => {
       await requestSigninToken(submittedEmail);
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "Error requesting signin token", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Error requesting signin token", ERROR_SUPPORT_CONTACT, errorToString(error)));
       return;
     }
 
@@ -105,7 +106,7 @@ const LoginPage: React.FC = () => {
       router.push("/profile");
     } catch (error) {
       console.error("Passkey authentication error:", error);
-      toast(SupportToast("", true, "Passkey authentication failed. Please try again", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Passkey authentication failed. Please try again", ERROR_SUPPORT_CONTACT, errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/pages/login.tsx
+++ b/apps/frontend/src/pages/login.tsx
@@ -12,9 +12,10 @@ import {
 } from "@/lib/auth";
 import { HeaderCover } from "@/components/ui/HeaderCover";
 import useSettings from "@/hooks/useSettings";
-import { UserLoginResponse } from "@types";
+import {errorToString, UserLoginResponse} from "@types";
 import { storage } from "@/lib/storage";
 import { logClientEvent } from "@/lib/frontend/metrics";
+import {SupportToast} from "@/components/ui/SupportToast";
 
 enum LoginState {
   EMAIL = "email",
@@ -50,7 +51,7 @@ const LoginPage: React.FC = () => {
       await requestSigninToken(submittedEmail);
     } catch (error) {
       console.error(error);
-      toast.error("Error requesting signin token");
+      toast(SupportToast("", true, "Error requesting signin token", "https://t.me/stevenelleman", errorToString(error)));
       return;
     }
 
@@ -104,7 +105,7 @@ const LoginPage: React.FC = () => {
       router.push("/profile");
     } catch (error) {
       console.error("Passkey authentication error:", error);
-      toast.error("Passkey authentication failed. Please try again.");
+      toast(SupportToast("", true, "Passkey authentication failed. Please try again", "https://t.me/stevenelleman", errorToString(error)));
     }
   };
 

--- a/apps/frontend/src/pages/people/[username].tsx
+++ b/apps/frontend/src/pages/people/[username].tsx
@@ -19,7 +19,8 @@ import { BASE_API_URL } from "@/config";
 import Link from "next/link";
 import { TensionSlider } from "../tensions";
 import { Icons } from "@/components/Icons";
-import {SupportToast} from "@/components/ui/SupportToast";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 interface CommentModalProps {
   username: string;
@@ -222,7 +223,7 @@ const UserProfilePage: React.FC = () => {
       toast.success("Comment added successfully!");
     } catch (error) {
       console.error("Error adding comment:", error);
-      toast(SupportToast("", true, "Failed to add comment", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Failed to add comment", ERROR_SUPPORT_CONTACT, errorToString(error)));
     }
   };
 
@@ -313,7 +314,7 @@ const UserProfilePage: React.FC = () => {
       }
     } catch (error) {
       console.error("Error updating PSI overlap:", error);
-      toast(SupportToast("", true, "Failed to update overlap. Please try again.", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Failed to update overlap. Please try again.", ERROR_SUPPORT_CONTACT, errorToString(error)));
     } finally {
       setRefreshLoading(false);
     }

--- a/apps/frontend/src/pages/people/[username].tsx
+++ b/apps/frontend/src/pages/people/[username].tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/router";
 import { storage } from "@/lib/storage";
 import { Connection, Session, User } from "@/lib/storage/types";
 import { toast } from "sonner";
-import { TapParams, ChipTapResponse } from "@types";
+import {TapParams, ChipTapResponse, errorToString} from "@types";
 import { AppButton } from "@/components/ui/Button";
 import Image from "next/image";
 import AppLayout from "@/layouts/AppLayout";
@@ -19,6 +19,7 @@ import { BASE_API_URL } from "@/config";
 import Link from "next/link";
 import { TensionSlider } from "../tensions";
 import { Icons } from "@/components/Icons";
+import {SupportToast} from "@/components/ui/SupportToast";
 
 interface CommentModalProps {
   username: string;
@@ -221,7 +222,7 @@ const UserProfilePage: React.FC = () => {
       toast.success("Comment added successfully!");
     } catch (error) {
       console.error("Error adding comment:", error);
-      toast.error("Failed to add comment.");
+      toast(SupportToast("", true, "Failed to add comment", "https://t.me/stevenelleman", errorToString(error)));
     }
   };
 
@@ -312,7 +313,7 @@ const UserProfilePage: React.FC = () => {
       }
     } catch (error) {
       console.error("Error updating PSI overlap:", error);
-      toast.error("Failed to update overlap. Please try again.");
+      toast(SupportToast("", true, "Failed to update overlap. Please try again.", "https://t.me/stevenelleman", errorToString(error)));
     } finally {
       setRefreshLoading(false);
     }

--- a/apps/frontend/src/pages/people/[username].tsx
+++ b/apps/frontend/src/pages/people/[username].tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/router";
 import { storage } from "@/lib/storage";
 import { Connection, Session, User } from "@/lib/storage/types";
 import { toast } from "sonner";
-import {TapParams, ChipTapResponse, errorToString} from "@types";
+import { TapParams, ChipTapResponse, errorToString } from "@types";
 import { AppButton } from "@/components/ui/Button";
 import Image from "next/image";
 import AppLayout from "@/layouts/AppLayout";
@@ -223,7 +223,15 @@ const UserProfilePage: React.FC = () => {
       toast.success("Comment added successfully!");
     } catch (error) {
       console.error("Error adding comment:", error);
-      toast(SupportToast("", true, "Failed to add comment", ERROR_SUPPORT_CONTACT, errorToString(error)));
+      toast(
+        SupportToast(
+          "",
+          true,
+          "Failed to add comment",
+          ERROR_SUPPORT_CONTACT,
+          errorToString(error)
+        )
+      );
     }
   };
 
@@ -314,7 +322,15 @@ const UserProfilePage: React.FC = () => {
       }
     } catch (error) {
       console.error("Error updating PSI overlap:", error);
-      toast(SupportToast("", true, "Failed to update overlap. Please try again.", ERROR_SUPPORT_CONTACT, errorToString(error)));
+      toast(
+        SupportToast(
+          "",
+          true,
+          "Failed to update overlap. Please try again",
+          ERROR_SUPPORT_CONTACT,
+          errorToString(error)
+        )
+      );
     } finally {
       setRefreshLoading(false);
     }

--- a/apps/frontend/src/pages/profile/edit.tsx
+++ b/apps/frontend/src/pages/profile/edit.tsx
@@ -14,8 +14,9 @@ import { useRouter } from "next/router";
 import { toast } from "sonner";
 import { CursiveLogo } from "@/components/ui/HeaderCover";
 import { updateChip } from "@/lib/chip/update";
-import {SupportToast} from "@/components/ui/SupportToast";
-import {errorToString} from "@types";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { errorToString } from "@types";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 type ChipEditFormData = {
   displayName?: string;
@@ -68,10 +69,12 @@ const ProfileEdit = () => {
       router.push("/profile");
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "Error updating chip", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Error updating chip", ERROR_SUPPORT_CONTACT, errorToString(error)));
     }
     setLoading(false);
   };
+
+  toast(SupportToast("", true, "Error updating chip", ERROR_SUPPORT_CONTACT, errorToString("")));
 
   return (
     <>

--- a/apps/frontend/src/pages/profile/edit.tsx
+++ b/apps/frontend/src/pages/profile/edit.tsx
@@ -74,8 +74,6 @@ const ProfileEdit = () => {
     setLoading(false);
   };
 
-  toast(SupportToast("", true, "Error updating chip", ERROR_SUPPORT_CONTACT, errorToString("")));
-
   return (
     <>
       {user ? (

--- a/apps/frontend/src/pages/profile/edit.tsx
+++ b/apps/frontend/src/pages/profile/edit.tsx
@@ -14,6 +14,8 @@ import { useRouter } from "next/router";
 import { toast } from "sonner";
 import { CursiveLogo } from "@/components/ui/HeaderCover";
 import { updateChip } from "@/lib/chip/update";
+import {SupportToast} from "@/components/ui/SupportToast";
+import {errorToString} from "@types";
 
 type ChipEditFormData = {
   displayName?: string;
@@ -66,7 +68,7 @@ const ProfileEdit = () => {
       router.push("/profile");
     } catch (error) {
       console.error(error);
-      toast.error("Error updating chip.");
+      toast(SupportToast("", true, "Error updating chip", "https://t.me/stevenelleman", errorToString(error)));
     }
     setLoading(false);
   };

--- a/apps/frontend/src/pages/register.tsx
+++ b/apps/frontend/src/pages/register.tsx
@@ -26,6 +26,7 @@ import { logClientEvent } from "@/lib/frontend/metrics";
 import { cn } from "@/lib/frontend/util";
 import { IoIosArrowBack as BackIcon } from "react-icons/io";
 import { SupportToast } from "@/components/ui/SupportToast";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 enum DisplayState {
   ENTER_EMAIL,
@@ -88,7 +89,7 @@ const Register: React.FC = () => {
       await requestSigninToken(submittedEmail);
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "Error requesting signin token", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Error requesting signin token", ERROR_SUPPORT_CONTACT, errorToString(error)));
       return;
     }
 
@@ -230,7 +231,7 @@ const Register: React.FC = () => {
         error: errorToString(error),
       });
       console.error(error);
-      toast(SupportToast("", true, "Failed to create account. Please try again", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Failed to create account. Please try again", ERROR_SUPPORT_CONTACT, errorToString(error)));
       return;
     }
   };

--- a/apps/frontend/src/pages/register.tsx
+++ b/apps/frontend/src/pages/register.tsx
@@ -25,6 +25,7 @@ import { HeaderCover } from "@/components/ui/HeaderCover";
 import { logClientEvent } from "@/lib/frontend/metrics";
 import { cn } from "@/lib/frontend/util";
 import { IoIosArrowBack as BackIcon } from "react-icons/io";
+import { SupportToast } from "@/components/ui/SupportToast";
 
 enum DisplayState {
   ENTER_EMAIL,
@@ -87,7 +88,7 @@ const Register: React.FC = () => {
       await requestSigninToken(submittedEmail);
     } catch (error) {
       console.error(error);
-      toast.error("Error requesting signin token");
+      toast(SupportToast("", true, "Error requesting signin token", "https://t.me/stevenelleman", errorToString(error)));
       return;
     }
 
@@ -229,7 +230,7 @@ const Register: React.FC = () => {
         error: errorToString(error),
       });
       console.error(error);
-      toast.error("Failed to create account. Please try again");
+      toast(SupportToast("", true, "Failed to create account. Please try again", "https://t.me/stevenelleman", errorToString(error)));
       return;
     }
   };

--- a/apps/frontend/src/pages/register.tsx
+++ b/apps/frontend/src/pages/register.tsx
@@ -227,6 +227,7 @@ const Register: React.FC = () => {
       toast.success("Account created successfully!");
       router.push("/profile");
     } catch (error) {
+      onGoBack();
       logClientEvent("register-create-account-error", {
         error: errorToString(error),
       });

--- a/apps/frontend/src/pages/tap.tsx
+++ b/apps/frontend/src/pages/tap.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
-import { TapParams, ChipTapResponse } from "@types";
+import {TapParams, ChipTapResponse, errorToString} from "@types";
 import { toast } from "sonner";
 import { storage } from "@/lib/storage";
 import { tapChip, updateTapLeaderboardEntry } from "@/lib/chip";
 import { CursiveLogo } from "@/components/ui/HeaderCover";
 import { logClientEvent } from "@/lib/frontend/metrics";
+import {SupportToast} from "@/components/ui/SupportToast";
 
 const TapPage: React.FC = () => {
   const router = useRouter();
@@ -97,7 +98,7 @@ const TapPage: React.FC = () => {
         }
       } catch (error) {
         console.error("Error tapping chip:", error);
-        toast.error("Error tapping chip");
+        toast(SupportToast("", true, "Error tapping chip", "https://t.me/stevenelleman", errorToString(error)));
         router.push("/");
       }
     };

--- a/apps/frontend/src/pages/tap.tsx
+++ b/apps/frontend/src/pages/tap.tsx
@@ -6,7 +6,8 @@ import { storage } from "@/lib/storage";
 import { tapChip, updateTapLeaderboardEntry } from "@/lib/chip";
 import { CursiveLogo } from "@/components/ui/HeaderCover";
 import { logClientEvent } from "@/lib/frontend/metrics";
-import {SupportToast} from "@/components/ui/SupportToast";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 const TapPage: React.FC = () => {
   const router = useRouter();
@@ -98,7 +99,7 @@ const TapPage: React.FC = () => {
         }
       } catch (error) {
         console.error("Error tapping chip:", error);
-        toast(SupportToast("", true, "Error tapping chip", "https://t.me/stevenelleman", errorToString(error)));
+        toast(SupportToast("", true, "Error tapping chip", ERROR_SUPPORT_CONTACT, errorToString(error)));
         router.push("/");
       }
     };

--- a/apps/frontend/src/pages/tensions.tsx
+++ b/apps/frontend/src/pages/tensions.tsx
@@ -84,7 +84,15 @@ export default function TensionsPage() {
       router.push("/profile");
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "Failed to save tensions. Please try again.", ERROR_SUPPORT_CONTACT, errorToString(error)));
+      toast(
+        SupportToast(
+          "",
+          true,
+          "Failed to save tensions. Please try again",
+          ERROR_SUPPORT_CONTACT,
+          errorToString(error)
+        )
+      );
     } finally {
       setLoading(false);
     }

--- a/apps/frontend/src/pages/tensions.tsx
+++ b/apps/frontend/src/pages/tensions.tsx
@@ -6,8 +6,9 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { tensionPairs } from "@/common/constants";
 import { logClientEvent } from "@/lib/frontend/metrics";
-import {SupportToast} from "@/components/ui/SupportToast";
-import {errorToString} from "@types";
+import { SupportToast } from "@/components/ui/SupportToast";
+import { errorToString } from "@types";
+import { ERROR_SUPPORT_CONTACT } from "@/constants";
 
 export default function TensionsPage() {
   const router = useRouter();
@@ -83,7 +84,7 @@ export default function TensionsPage() {
       router.push("/profile");
     } catch (error) {
       console.error(error);
-      toast(SupportToast("", true, "Failed to save tensions. Please try again.", "https://t.me/stevenelleman", errorToString(error)));
+      toast(SupportToast("", true, "Failed to save tensions. Please try again.", ERROR_SUPPORT_CONTACT, errorToString(error)));
     } finally {
       setLoading(false);
     }

--- a/apps/frontend/src/pages/tensions.tsx
+++ b/apps/frontend/src/pages/tensions.tsx
@@ -6,6 +6,8 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { tensionPairs } from "@/common/constants";
 import { logClientEvent } from "@/lib/frontend/metrics";
+import {SupportToast} from "@/components/ui/SupportToast";
+import {errorToString} from "@types";
 
 export default function TensionsPage() {
   const router = useRouter();
@@ -81,7 +83,7 @@ export default function TensionsPage() {
       router.push("/profile");
     } catch (error) {
       console.error(error);
-      toast.error("Failed to save tensions. Please try again.");
+      toast(SupportToast("", true, "Failed to save tensions. Please try again.", "https://t.me/stevenelleman", errorToString(error)));
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
The Support Toast allows the toast message / error to be directly sent to a telegram chat (in this case, me). 

I have two chunks of work focused on error handling. One chunk focusing on user support (this one, a little bit in the next PR focused on making error toasts more actionable), and the other focused on better internal service logging. 

I will probably come to regret this, as I'm flooded with support requests. That being said, quite curious to see how the community receives / uses it. 

Tried to keep styling very consistent with the sonner toast library: 
<img width="347" alt="Screenshot 2024-10-23 at 3 48 03 AM" src="https://github.com/user-attachments/assets/2e49385f-9e03-4abb-be32-46f5706cf607">
