### PR TITLE
Autofocus on Bio Textarea in Registration

### DIFF
--- a/apps/frontend/src/features/register/EnterUserInfo.tsx
+++ b/apps/frontend/src/features/register/EnterUserInfo.tsx
@@ -202,6 +202,8 @@ const EnterUserInfo: React.FC<EnterUserInfoProps> = ({
                     onChange={(e) => handleInputChange(e.target.value)}
                     onKeyDown={handleKeyDown}
                     aria-label={steps[step].question}
+                    required={steps[step].required}
+                    autoFocus
                   />
                   <button
                     className="text-sm text-link-primary font-sans font-semibold"


### PR DESCRIPTION
When you submit one entry it automatically focuses you on the next, _except_ for the bio. This means you need to click the bio to begin typing. This fixes the issue so that you autofocus on the component as soon as it renders. 

<img width="361" alt="Screenshot 2024-10-26 at 10 19 43 AM" src="https://github.com/user-attachments/assets/b566932d-918b-4f95-9b40-424f7e3f403c">


