### PR TITLE
Delete Revoked Token If Import Fails

### DIFF
--- a/apps/frontend/src/lib/oauth/imports.ts
+++ b/apps/frontend/src/lib/oauth/imports.ts
@@ -11,6 +11,7 @@ import {
 import { toast } from "sonner";
 import { MapStravaActivityStatsToLeaderboardEntryRequest } from "./strava";
 import { MapGithubCommitContributionsToLeaderboardEntry } from "./github";
+import { storage } from "@/lib/storage";
 
 export function MapResponseToLeaderboardEntryRequest(
   authToken: string,
@@ -156,8 +157,11 @@ export async function importOAuthData(
       data
     );
   } catch (error) {
+    // If error delete access token -- the token may have been revoked
+    // By deleting the access token we'll fetch a new one on a re-attempt
+    storage.getOAuthAccessToken(options.type);
     console.error("Error importing data:", errorToString(error));
-    toast.error("Unable to import OAuth data");
+    toast.error("Import failed, token removed. Rerun if token was revoked.");
     return null;
   }
 }

--- a/apps/frontend/src/lib/oauth/imports.ts
+++ b/apps/frontend/src/lib/oauth/imports.ts
@@ -159,7 +159,7 @@ export async function importOAuthData(
   } catch (error) {
     // If error delete access token -- the token may have been revoked
     // By deleting the access token we'll fetch a new one on a re-attempt
-    storage.getOAuthAccessToken(options.type);
+    storage.deleteOAuthAccessToken(options.type);
     console.error("Error importing data:", errorToString(error));
     toast.error("Import failed, token removed. Rerun if token was revoked.");
     return null;

--- a/apps/frontend/src/lib/storage/index.ts
+++ b/apps/frontend/src/lib/storage/index.ts
@@ -33,6 +33,7 @@ export interface ClientStorage {
   getSession(): Promise<Session | undefined>;
   saveOAuthAccessToken(app: string, token: AccessToken): Promise<void>;
   getOAuthAccessToken(app: string): Promise<AccessToken | undefined>;
+  deleteOAuthAccessToken(app: string): Promise<void>;
   saveTapInfo(tapInfo: TapInfo): Promise<void>;
   loadSavedTapInfo(): Promise<TapInfo | undefined>;
   deleteSavedTapInfo(): Promise<void>;

--- a/apps/frontend/src/lib/storage/localStorage/client.ts
+++ b/apps/frontend/src/lib/storage/localStorage/client.ts
@@ -41,6 +41,7 @@ import {
 import { createTapBackMessage } from "./user/connection/message/tapBack";
 import { processNewMessages } from "./user/connection/message";
 import {
+  deleteOAuthAccessToken,
   getOAuthAccessToken,
   saveOAuthAccessToken,
 } from "@/lib/storage/localStorage/user/oauth";
@@ -85,6 +86,10 @@ export class LocalStorage implements ClientStorage {
 
   async getOAuthAccessToken(app: string): Promise<AccessToken | undefined> {
     return getOAuthAccessToken(app);
+  }
+
+  async deleteOAuthAccessToken(app: string): Promise<void> {
+    return deleteOAuthAccessToken(app);
   }
 
   async saveTapInfo(tapInfo: TapInfo): Promise<void> {

--- a/apps/frontend/src/lib/storage/localStorage/user/oauth.ts
+++ b/apps/frontend/src/lib/storage/localStorage/user/oauth.ts
@@ -36,3 +36,15 @@ export const getOAuthAccessToken = async (
 
   return undefined;
 };
+
+export const deleteOAuthAccessToken = async (
+  app: string
+): Promise<void> => {
+  const { user } = await getUserAndSession();
+
+  if (user.oauth && user.oauth[app]) {
+    delete user.oauth[app];
+  }
+
+  return;
+};

--- a/apps/frontend/src/lib/storage/localStorage/user/oauth.ts
+++ b/apps/frontend/src/lib/storage/localStorage/user/oauth.ts
@@ -1,7 +1,10 @@
 import { AccessToken, AccessTokenSchema } from "@types";
 import { getUserAndSession } from ".";
 import { saveBackupAndUpdateStorage } from "../utils";
-import { createOAuthBackup } from "@/lib/backup";
+import {
+  createOAuthBackup,
+  createOAuthDeletionBackup
+} from "@/lib/backup";
 
 export const saveOAuthAccessToken = async (
   app: string,
@@ -40,11 +43,19 @@ export const getOAuthAccessToken = async (
 export const deleteOAuthAccessToken = async (
   app: string
 ): Promise<void> => {
-  const { user } = await getUserAndSession();
+  const { user, session } = await getUserAndSession();
 
-  if (user.oauth && user.oauth[app]) {
-    delete user.oauth[app];
-  }
+  const oauthDeletionBackup = createOAuthDeletionBackup({
+    email: user.email,
+    password: session.backupMasterPassword,
+    oauthApp: {
+      app,
+    },
+  });
 
-  return;
+  await saveBackupAndUpdateStorage({
+    user,
+    session,
+    newBackupData: [oauthDeletionBackup],
+  });
 };

--- a/apps/frontend/src/lib/storage/types/user/oauth.ts
+++ b/apps/frontend/src/lib/storage/types/user/oauth.ts
@@ -7,3 +7,9 @@ export const OAuthDataSchema = z.object({
 });
 
 export type OAuthData = z.infer<typeof OAuthDataSchema>;
+
+export const OAuthAppSchema = z.object({
+  app: z.string(),
+});
+
+export type OAuthApp = z.infer<typeof OAuthAppSchema>;

--- a/packages/types/src/user/index.ts
+++ b/packages/types/src/user/index.ts
@@ -16,6 +16,7 @@ export enum BackupEntryType {
   LAST_MESSAGE_FETCHED_AT = "LAST_MESSAGE_FETCHED_AT",
   OAUTH = "OAUTH",
   LOCATION = "LOCATION",
+  DELETE_OAUTH = "DELETE_OAUTH",
 }
 
 export const BackupEntryTypeSchema = z.nativeEnum(BackupEntryType);


### PR DESCRIPTION
I wanted to make a screen recording of the full GH authorization flow. I revoked my current oauth token in GH, thinking we had handled this case. When I attempted to import GH data the flow failed -- the access token had been revoked but looked valid to the client so it kept using the same token rather than removing it. This PR removes the access token if an import fails, forcing the client to create a new access token. 