### PR TITLE
Basic Telegram notification bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Backend:
 - Run `pnpm prisma generate` to generate the prisma client
 - `pnpm run dev`
 
+Telegram:
+
+- Create a bot on Telegram using BotFather to test with
+- In `apps/backend/.env`:
+  - Set `TELEGRAM_BOT_API` to the bot api key
+  - Set `TELEGRAM_BOT_USERNAME` to be the bot username
+  - Set `TELEGRAM_BOT_START_DELAY_MS` to the delay in ms before starting the bot, defaults to 0, mostly relevant in prod
+
 Testing:
 
 - This is meant to be a mobile browser app. You can either test this on mobile browser by connecting it to localhost or using ngrok/similar service, or test from a desktop web browser using mobile view

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Backend:
 
 Telegram:
 
-- Create a bot on Telegram using BotFather to test with
+- Create a bot on Telegram using BotFather (https://t.me/BotFather) to test with
 - In `apps/backend/.env`:
   - Set `TELEGRAM_BOT_API` to the bot api key
   - Set `TELEGRAM_BOT_USERNAME` to be the bot username

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -18,6 +18,7 @@
     "elliptic": "^6.5.7",
     "express": "^4.21.0",
     "ffjavascript": "^0.3.0",
+    "grammy": "^1.30.1",
     "hash.js": "^1.1.7",
     "js-sha256": "^0.11.0",
     "unique-names-generator": "^4.7.1",

--- a/apps/backend/prisma/migrations/20241030190429_add_notification_user_id/migration.sql
+++ b/apps/backend/prisma/migrations/20241030190429_add_notification_user_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "notificationUserId" TEXT;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   registeredWithPasskey Boolean
   passkeyAuthPublicKey  String?
   createdAt             DateTime    @default(now())
+  notificationUserId    String?
   AuthToken             AuthToken[]
   Backup                Backup[]
 }

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -5,8 +5,10 @@ import messageRoutes from "./routes/message";
 import healthRoutes from "./routes/health";
 import oauthRoutes from "./routes/oauth";
 import lannaRoutes from "./routes/lanna";
+import notificationRoutes from "./routes/notification";
 import { FRONTEND_URL } from "./constants";
 import { IntersectionState } from "@types";
+import { Controller } from "./lib/controller";
 const cors = require("cors");
 
 const app = express();
@@ -22,9 +24,20 @@ app.use("/api/chip", chipRoutes);
 app.use("/api/oauth", oauthRoutes);
 app.use("/api/lanna", lannaRoutes);
 app.use("/api/message", messageRoutes);
+app.use("/api/notification", notificationRoutes);
 app.use("/", healthRoutes);
 
 app.locals.intersectionState = {} as IntersectionState;
+
+const controller = new Controller();
+controller
+  .NotificationInitialize()
+  .then(() => {
+    console.log("Notification service initialized");
+  })
+  .catch((error) => {
+    console.error("Failed to initialize notification service: ", error);
+  });
 
 const PORT = process.env.PORT || 8080;
 app.listen(PORT, () => {

--- a/apps/backend/src/lib/controller/chip/managed/client.ts
+++ b/apps/backend/src/lib/controller/chip/managed/client.ts
@@ -9,6 +9,7 @@ import {
   LeaderboardEntryType,
 } from "@types";
 import { Chip } from "@/lib/controller/chip/types";
+import { TelegramNotificationClient } from "../../notification/telegram/client";
 
 // NOTE: Hoist all prototype methods -- if you do not import the method file, the method(s) will evaluate to undefined at runtime
 import("@/lib/controller/chip/managed/update");
@@ -18,9 +19,11 @@ import("@/lib/controller/chip/managed/tap");
 
 export class ManagedChipClient implements iChipClient {
   prismaClient: PrismaClient;
+  notificationClient: TelegramNotificationClient;
 
   constructor() {
     this.prismaClient = new PrismaClient();
+    this.notificationClient = new TelegramNotificationClient();
   }
 
   // @ts-expect-error (ts2391: function implementation does not immediately follow declaration)

--- a/apps/backend/src/lib/controller/index.ts
+++ b/apps/backend/src/lib/controller/index.ts
@@ -28,14 +28,17 @@ import { iChipClient } from "@/lib/controller/chip/interfaces";
 import { ManagedChipClient } from "@/lib/controller/chip/managed/client";
 import { SESEmailClient } from "@/lib/controller/email/ses/client";
 import { iEmailClient } from "@/lib/controller/email/interfaces";
-import {iOAuthClient} from "@/lib/controller/oauth/interfaces";
-import {BespokeOAuthClient} from "@/lib/controller/oauth/bespoke/client";
+import { iOAuthClient } from "@/lib/controller/oauth/interfaces";
+import { BespokeOAuthClient } from "@/lib/controller/oauth/bespoke/client";
+import { TelegramNotificationClient } from "./notification/telegram/client";
+import { iNotificationClient } from "./notification/interfaces";
 
 export class Controller {
   postgresClient: iPostgresClient; // Use interface so that it can be mocked out
   chipClient: iChipClient;
   emailClient: iEmailClient;
   oauthClient: iOAuthClient;
+  notificationClient: iNotificationClient;
 
   constructor() {
     // Default client, could also pass through mock
@@ -49,7 +52,18 @@ export class Controller {
     // Bespoke OAuth client -- in theory could change out for mature OAuth library, if we have the need and a good candidate
     this.oauthClient = new BespokeOAuthClient();
 
+    // Notification client, currently only Telegram
+    this.notificationClient = new TelegramNotificationClient();
+
     // Over time more clients will be added (e.g. nitro enclave client)...
+  }
+
+  NotificationInitialize(): Promise<void> {
+    return this.notificationClient.Initialize();
+  }
+
+  SendNotification(userId: string, message: string): Promise<boolean> {
+    return this.notificationClient.SendNotification(userId, message);
   }
 
   PostgresHealthCheck(): Promise<boolean> {

--- a/apps/backend/src/lib/controller/notification/interfaces.ts
+++ b/apps/backend/src/lib/controller/notification/interfaces.ts
@@ -1,0 +1,4 @@
+export interface iNotificationClient {
+  Initialize(): Promise<void>;
+  SendNotification(userId: string, message: string): Promise<boolean>;
+}

--- a/apps/backend/src/lib/controller/notification/telegram/client.ts
+++ b/apps/backend/src/lib/controller/notification/telegram/client.ts
@@ -1,0 +1,114 @@
+import { Bot } from "grammy";
+import { iNotificationClient } from "../interfaces";
+import { PrismaClient } from "@prisma/client";
+
+export class TelegramNotificationClient implements iNotificationClient {
+  private bot: Bot | undefined;
+  private readonly maxRetries = 3;
+  private readonly retryDelay = 5000;
+  prismaClient: PrismaClient | undefined;
+
+  constructor() {
+    if (!process.env.TELEGRAM_BOT_API) {
+      // No token, so we don't initialize
+      return;
+    }
+    this.bot = new Bot(process.env.TELEGRAM_BOT_API);
+    this.prismaClient = new PrismaClient();
+  }
+
+  private async setupBot(): Promise<void> {
+    if (!this.bot) {
+      throw new Error("Bot is not initialized");
+    }
+
+    this.bot.command("start", async (ctx) => {
+      // The start parameter will be available in ctx.match
+      const startParameter = ctx.match;
+
+      if (startParameter) {
+        // This is where you can link the Telegram user with your backend user
+        const telegramUserId = ctx.from?.id;
+        const backendUserId = startParameter;
+
+        if (!telegramUserId || !backendUserId) {
+          throw new Error("Invalid user IDs");
+        }
+
+        try {
+          // Store the association in your database
+          await this.prismaClient?.user.update({
+            where: { id: backendUserId },
+            data: { notificationUserId: telegramUserId?.toString() },
+          });
+
+          await ctx.reply(
+            `I'm Curtis, the Cursive Connections bot. I'm here to help you discover and deepen your connections.`
+          );
+        } catch (error) {
+          await ctx.reply(
+            "Sorry, there was an error linking your account. Please try connecting again."
+          );
+          console.error("Linking error:", error);
+        }
+      } else {
+        await ctx.reply(
+          "Welcome! Please register for notifications from your profile page."
+        );
+      }
+    });
+
+    this.bot.start({
+      onStart: (info) => {
+        console.log(`[TELEGRAM] Started bot '${info.username}' successfully!`);
+      },
+    });
+  }
+
+  async Initialize(): Promise<void> {
+    const startDelay = parseInt(process.env.TELEGRAM_BOT_START_DELAY_MS ?? "0");
+    await new Promise((resolve) => setTimeout(resolve, startDelay));
+
+    for (let i = 0; i < this.maxRetries; i++) {
+      try {
+        await this.setupBot();
+        console.log("Telegram notification client initialized");
+        return;
+      } catch (error) {
+        console.log(
+          `Telegram initialization failed, retrying in ${this.retryDelay}ms...`
+        );
+        await new Promise((resolve) => setTimeout(resolve, this.retryDelay));
+      }
+    }
+  }
+
+  async SendNotification(userId: string, message: string): Promise<boolean> {
+    if (!this.bot) {
+      console.error("Telegram client not initialized");
+      return false;
+    }
+
+    try {
+      const user = await this.prismaClient?.user.findUnique({
+        where: { id: userId },
+      });
+
+      if (!user) {
+        console.error("User not found");
+        return false;
+      }
+
+      if (!user?.notificationUserId) {
+        console.error("User not linked to Telegram");
+        return false;
+      }
+
+      await this.bot.api.sendMessage(user.notificationUserId, message);
+      return true;
+    } catch (error) {
+      console.error("Failed to send Telegram notification:", error);
+      return false;
+    }
+  }
+}

--- a/apps/backend/src/routes/chip/update.ts
+++ b/apps/backend/src/routes/chip/update.ts
@@ -27,7 +27,7 @@ router.post(
         return res.status(401).json({ error: "Invalid authentication token" });
       }
 
-      const updatedChip = await controller.UpdateChip(validatedData);
+      await controller.UpdateChip(validatedData);
 
       return res.status(200).json({});
     } catch (error) {

--- a/apps/backend/src/routes/notification/index.ts
+++ b/apps/backend/src/routes/notification/index.ts
@@ -1,0 +1,49 @@
+import express, { Request, Response } from "express";
+import { ErrorResponse, errorToString } from "@types";
+import { Controller } from "@/lib/controller";
+
+const router = express.Router();
+const controller = new Controller();
+
+/**
+ * @route GET /api/notification/telegram/link
+ * @desc Redirect to Telegram to link account
+ */
+router.get(
+  "/telegram/link",
+  async (
+    req: Request<
+      {},
+      {},
+      {
+        authToken: string;
+      }
+    >,
+    res: Response<{} | ErrorResponse>
+  ) => {
+    try {
+      const { authToken } = req.query;
+      if (!authToken) {
+        return res.status(400).json({ error: "Missing auth token" });
+      }
+
+      // Fetch user by auth token
+      const user = await controller.GetUserByAuthToken(authToken.toString());
+      if (!user) {
+        return res.status(401).json({ error: "Invalid auth token" });
+      }
+
+      const botUsername =
+        process.env.TELEGRAM_BOT_USERNAME ?? "CurtisCursiveBot";
+
+      const botLink = `https://t.me/${botUsername}?start=${user.id}`;
+      return res.redirect(botLink);
+    } catch (error) {
+      return res.status(500).json({
+        error: errorToString(error),
+      });
+    }
+  }
+);
+
+export default router;

--- a/apps/frontend/src/features/notification/AddNotificationButton.tsx
+++ b/apps/frontend/src/features/notification/AddNotificationButton.tsx
@@ -1,0 +1,59 @@
+import { FC } from "react";
+import { useRouter } from "next/router";
+import { toast } from "sonner";
+import { storage } from "@/lib/storage";
+import { BASE_API_URL } from "@/config";
+import { logClientEvent } from "@/lib/frontend/metrics";
+import { AppButton } from "@/components/ui/Button";
+
+interface AddNotificationButtonProps {
+  // If you need to open in new tab vs same window
+  openInNewTab?: boolean;
+  // Optional custom button text
+  buttonText?: string;
+  // Optional className for additional styling
+  className?: string;
+}
+
+export const AddNotificationButton: FC<AddNotificationButtonProps> = ({
+  openInNewTab = true,
+  buttonText = "Notifications",
+  className,
+}) => {
+  const router = useRouter();
+
+  const handleNotificationSetup = async () => {
+    logClientEvent("set-up-telegram", {});
+
+    const { user, session } = await storage.getUserAndSession();
+    if (
+      user &&
+      session &&
+      session.authTokenValue &&
+      session.authTokenExpiresAt > new Date()
+    ) {
+      const url = `${BASE_API_URL}/notification/telegram/link?authToken=${session.authTokenValue}`;
+
+      if (openInNewTab) {
+        window.open(url, "_blank");
+      } else {
+        window.location.href = url;
+      }
+    } else {
+      toast.error("Please log in to access Cherry.");
+      router.push("/login");
+    }
+  };
+
+  return (
+    <AppButton
+      variant="outline"
+      onClick={handleNotificationSetup}
+      className={className}
+    >
+      <span className="text-[14px]">{buttonText}</span>
+    </AppButton>
+  );
+};
+
+export default AddNotificationButton;

--- a/apps/frontend/src/pages/profile/index.tsx
+++ b/apps/frontend/src/pages/profile/index.tsx
@@ -18,6 +18,7 @@ import { logoutUser } from "@/lib/auth";
 import { logClientEvent } from "@/lib/frontend/metrics";
 import ImportGithubButton from "@/features/oauth/ImportGithubButton";
 import ImportStravaButton from "@/features/oauth/ImportStravaButton";
+import AddNotificationButton from "@/features/notification/AddNotificationButton";
 
 const ProfilePage: React.FC = () => {
   const router = useRouter();
@@ -108,6 +109,9 @@ const ProfilePage: React.FC = () => {
                     <span className="text-[14px]">Activity</span>
                   </AppButton>
                 </Link>
+                <div className="w-fit">
+                  <AddNotificationButton />
+                </div>
               </div>
             </div>
           </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       ffjavascript:
         specifier: ^0.3.0
         version: 0.3.0
+      grammy:
+        specifier: ^1.30.1
+        version: 1.30.1
       hash.js:
         specifier: ^1.1.7
         version: 1.1.7
@@ -355,6 +358,9 @@ packages:
 
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
+
+  '@grammyjs/types@3.14.0':
+    resolution: {integrity: sha512-uUVikYAiHNU8CvkeQ6YA/QPbMLgTTpFVLp83VkXCs423w6cDsvfdA6bcrQJGUnc/Q6zHQXXZUftXDYl2b/6L4A==}
 
   '@headlessui/react@2.1.9':
     resolution: {integrity: sha512-ckWw7vlKtnoa1fL2X0fx1a3t/Li9MIKDVXn3SgG65YlxvDAsNrY39PPCxVM7sQRA7go2fJsuHSSauKFNaJHH7A==}
@@ -898,6 +904,10 @@ packages:
       react:
         optional: true
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1406,6 +1416,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   express@4.21.0:
     resolution: {integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==}
     engines: {node: '>= 0.10.0'}
@@ -1552,6 +1566,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  grammy@1.30.1:
+    resolution: {integrity: sha512-k7Ggvmiaxh/bkI22g/gIL4zCvTIwSNTjreObbEMxIsUkEpv9ZNylJaPONAZHWsojVws5f8r1RL6CjOYs02iGTQ==}
+    engines: {node: ^12.20.0 || >=14.13.1}
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -3055,7 +3073,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -3093,6 +3111,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.8': {}
 
+  '@grammyjs/types@3.14.0': {}
+
   '@headlessui/react@2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react': 0.26.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3107,7 +3127,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3714,7 +3734,7 @@ snapshots:
       '@typescript-eslint/types': 8.7.0
       '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 8.7.0
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.2
@@ -3730,7 +3750,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.7.0(typescript@5.6.2)
       '@typescript-eslint/utils': 8.7.0(eslint@8.57.1)(typescript@5.6.2)
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@5.5.0)
       ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
       typescript: 5.6.2
@@ -3744,7 +3764,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.7.0
       '@typescript-eslint/visitor-keys': 8.7.0
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@5.5.0)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -3779,6 +3799,10 @@ snapshots:
     optionalDependencies:
       next: 14.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
 
   accepts@1.3.8:
     dependencies:
@@ -4070,10 +4094,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.3.7(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -4305,10 +4325,10 @@ snapshots:
   eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@5.5.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -4321,7 +4341,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -4343,7 +4363,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.7.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -4426,7 +4446,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -4475,6 +4495,8 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  event-target-shim@5.0.1: {}
 
   express@4.21.0:
     dependencies:
@@ -4684,6 +4706,16 @@ snapshots:
       get-intrinsic: 1.2.4
 
   graceful-fs@4.2.11: {}
+
+  grammy@1.30.1:
+    dependencies:
+      '@grammyjs/types': 3.14.0
+      abort-controller: 3.0.0
+      debug: 4.3.7(supports-color@5.5.0)
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   graphemer@1.4.0: {}
 


### PR DESCRIPTION
All code for a basic telegram notification bot are in this PR. The prod one is "CurtisConnectionBot", the environment variables for him are already upstreamed to prod Render.

To test you should make your own bot as Telegram only allows one running instance of a Bot at a time. Instructions for this are in README.md.

There's an example button to connect to the bot on `profile/index.tsx`. This can be removed until we have better designs for it, but I left it there for easy testing.

There's an example usage of the notification message when a user updates their chip profile. This can be removed once it is added in other places.

There is a migration in this PR, so we need to ensure that gets upstreamed to the backend.