### PR TITLE
Add Overlapping Community Leaderboards to PSI Section

### DIFF
--- a/apps/backend/src/routes/user/refresh_intersection.ts
+++ b/apps/backend/src/routes/user/refresh_intersection.ts
@@ -24,14 +24,15 @@ router.post(
       }
 
       req.app.locals.intersectionState[secretHash][index] = intersectionState;
-      const { tensions: tensions0, contacts: contacts0 } = intersectionState;
+      const { tensions: tensions0, contacts: contacts0, communities: communities0 } = intersectionState;
 
       if (req.app.locals.intersectionState[secretHash][1 - index]) {
-        const { tensions: tensions1, contacts: contacts1 } =
+        const { tensions: tensions1, contacts: contacts1, communities: communities1 } =
           req.app.locals.intersectionState[secretHash][1 - index];
 
         const newTensions: string[] = [];
         const newContacts: string[] = [];
+        const newCommunities: string[] = [];
 
         if (
           tensions0.length !== 0 &&
@@ -59,11 +60,22 @@ router.post(
           }
         }
 
+        // Create a Set from communities0 for efficient lookup
+        const communitiesSet = new Set(communities0);
+
+        // Find intersection by checking each contact in contacts1
+        for (const community of communities1) {
+          if (communitiesSet.has(community)) {
+            newCommunities.push(community);
+          }
+        }
+
         return res.status(200).json({
           success: true,
           verifiedIntersectionState: {
             tensions: newTensions,
             contacts: newContacts,
+            communities: newCommunities,
           },
         });
       }
@@ -73,6 +85,7 @@ router.post(
         verifiedIntersectionState: {
           tensions: [],
           contacts: [],
+          communities: [],
         },
       });
     } catch (error) {

--- a/apps/frontend/src/lib/storage/types/user/connection/psiData.ts
+++ b/apps/frontend/src/lib/storage/types/user/connection/psiData.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 export const PSIDataSchema = z.object({
   sharedConnections: z.array(z.string()),
   sharedLannaInterests: z.array(z.string()),
+  sharedCommunities: z.array(z.string()),
   lastUpdatedAt: nullToUndefined(z.coerce.date()),
 });
 

--- a/apps/frontend/src/pages/people/[username].tsx
+++ b/apps/frontend/src/pages/people/[username].tsx
@@ -208,7 +208,7 @@ const HumanReadableValues: Record<string, string> = {
   "DEVCON": "Devcon",
   "TOTAL_TAP_COUNT": "total tap count",
   "STRAVA_PREVIOUS_MONTH_RUN_DISTANCE": "running distance over last month",
-  "GITHUB_LANNA_COMMITS": "total Github commits",
+  "GITHUB_LANNA_COMMITS": "total Github contributions",
   "LANNA_TOTAL_WORKOUT_COUNT": "total workouts"
 }
 
@@ -234,13 +234,14 @@ const UserProfilePage: React.FC = () => {
   const [gotLeaderboardPositions, setGotLeaderboardPositions] = useState(false);
   const [leaderboardPositions, setLeaderboardPositions] = useState<LeaderboardPositionRecord>({});
 
+  // NOTE: should leaderboard position state be added to useEffect dependency array?
   useEffect(() => {
     const fetchLeaderboardDetailsForCommunities = async () => {
       if (verifiedIntersection?.communities && !gotLeaderboardPositions) {
 
         // Only run computation once there's a community overlap
-        for (let issuer of verifiedIntersection?.communities) {
-          let community: ChipIssuer =  ChipIssuerSchema.parse(issuer);
+        for (const issuer of verifiedIntersection?.communities) {
+          const community: ChipIssuer =  ChipIssuerSchema.parse(issuer);
 
           let leaderboardTypes: LeaderboardEntryType[] = SharedLeaderboards;
           switch(community) {
@@ -255,7 +256,7 @@ const UserProfilePage: React.FC = () => {
           }
 
           // Shared leaderboards should be run for each shared communities
-          for (let entryType of leaderboardTypes) {
+          for (const entryType of leaderboardTypes) {
             try {
               const details: LeaderboardDetails | null = await getUserLeaderboardDetails(community, entryType);
               if (details && details.userPosition > 0 && details.userPosition < 11) {
@@ -396,7 +397,7 @@ const UserProfilePage: React.FC = () => {
       }
 
       const communitySet = new Set<string>();
-      for (let chip of user.chips) {
+      for (const chip of user.chips) {
         communitySet.add(chip.issuer);
       }
       const communityData = Array.from(communitySet.keys());
@@ -662,11 +663,11 @@ const UserProfilePage: React.FC = () => {
                       {/* After communities are ironed out add links to community page and / or dashboards */}
                       {
                         Object.keys(leaderboardPositions).map((community: string) => {
-                          let messages: string[] = [];
-                          let name: string = HumanReadableValues[community];
+                          const messages: string[] = [];
+                          const name: string = HumanReadableValues[community];
 
-                          for (let entry of leaderboardPositions[community]) {
-                            let board: string = HumanReadableValues[entry.type];
+                          for (const entry of leaderboardPositions[community]) {
+                            const board: string = HumanReadableValues[entry.type];
 
                             const message = `#${entry.position} for ${board} at ${name}.`;
                             messages.push(message);

--- a/apps/frontend/src/pages/profile/index.tsx
+++ b/apps/frontend/src/pages/profile/index.tsx
@@ -94,11 +94,11 @@ const ProfilePage: React.FC = () => {
           <div className="flex flex-col  mt-[38px] px-3 pb-4">
             <div className="flex flex-col gap-4 w-full">
               <div className="flex flex-col">
-                <span className="text-[30px] font-semibold tracking-[-0.22px] font-sans text-label-primary">
-                  {user?.userData.displayName}
-                </span>
-                <span className="text-[14px] font-medium font-sans text-label-tertiary">
+                <span className="text-[30px] font-semibold tracking-[-0.22px] font-sans text-primary">
                   {`${user?.userData.username}`}
+                </span>
+                <span className="text-[14px] font-medium font-sans text-tertiary">
+                  {user?.userData.displayName}
                 </span>
               </div>
               <div className="flex items-center gap-2">

--- a/apps/frontend/src/pages/profile/overview.tsx
+++ b/apps/frontend/src/pages/profile/overview.tsx
@@ -62,11 +62,11 @@ export default function ProfileOverview() {
     >
       <div className="flex flex-col gap-3 mt-[46px]">
         <div className="flex flex-col px-4">
-          <span className="text-[30px] font-semibold tracking-[-0.22px] font-sans text-label-primary">
-            {user?.userData.displayName}
+          <span className="text-[30px] font-semibold tracking-[-0.22px] font-sans">
+            {`${user?.userData.username}`}
           </span>
-          <span className="text-[14px] font-medium font-sans text-label-tertiary">
-            {`@${user?.userData.username}`}
+          <span className="text-[14px] font-medium font-sans text-tertiary">
+            {user?.userData.displayName}
           </span>
           {user?.userData?.pronouns && (
             <span className="text-[14px] font-medium font-sans text-label-tertiary">

--- a/packages/types/src/chip/index.ts
+++ b/packages/types/src/chip/index.ts
@@ -117,6 +117,19 @@ export enum LeaderboardEntryType {
   LANNA_TOTAL_WORKOUT_COUNT = "LANNA_TOTAL_WORKOUT_COUNT",
 }
 
+export const SharedLeaderboards: LeaderboardEntryType[] = [
+  LeaderboardEntryType.TOTAL_TAP_COUNT,
+  LeaderboardEntryType.STRAVA_PREVIOUS_MONTH_RUN_DISTANCE,
+  LeaderboardEntryType.GITHUB_WEEK_OCT_20_COMMITS,
+];
+
+export const LannaLeaderboards: LeaderboardEntryType[] = [
+  LeaderboardEntryType.WEEK_OCT_20_TAP_COUNT,
+  LeaderboardEntryType.WEEK_OCT_27_TAP_COUNT,
+  LeaderboardEntryType.GITHUB_LANNA_COMMITS,
+  LeaderboardEntryType.LANNA_TOTAL_WORKOUT_COUNT,
+]
+
 export const LeaderboardEntryTypeSchema = z.nativeEnum(LeaderboardEntryType);
 
 export const UpdateLeaderboardEntryRequestSchema = z.object({

--- a/packages/types/src/user/index.ts
+++ b/packages/types/src/user/index.ts
@@ -207,7 +207,11 @@ export const IntersectionStateSchema = z.record(
   z.string(),
   z.record(
     z.number().int(),
-    z.object({ tensions: z.array(z.string()), contacts: z.array(z.string()) })
+    z.object({
+      tensions: z.array(z.string()),
+      contacts: z.array(z.string()),
+      communities: z.array(z.string()),
+    })
   )
 );
 
@@ -220,6 +224,7 @@ export const RefreshIntersectionRequestSchema = z.object({
   intersectionState: z.object({
     tensions: z.array(z.string()),
     contacts: z.array(z.string()),
+    communities: z.array(z.string()),
   }),
 });
 
@@ -232,6 +237,7 @@ export const RefreshIntersectionResponseSchema = z.object({
   verifiedIntersectionState: z.object({
     tensions: z.array(z.string()),
     contacts: z.array(z.string()),
+    communities: z.array(z.string()),
   }),
 });
 


### PR DESCRIPTION
If there are shared communities AND top 10 leaderboard entries: 
<img width="430" alt="Screenshot 2024-11-06 at 12 17 12 AM" src="https://github.com/user-attachments/assets/ee90d3e4-6a25-4211-aec9-0ba8cb341d53">

If there are no shared communities OR no top 10 leaderboard entries: 
<img width="431" alt="Screenshot 2024-11-06 at 12 16 15 AM" src="https://github.com/user-attachments/assets/91930774-0ceb-4f5f-8f1b-4a8f3166c4a4">
