### PR TITLE
Extend Telegram Bot Functionality

### DIFF
--- a/apps/backend/prisma/migrations/20241106093803_add_notification_setting_to_user/migration.sql
+++ b/apps/backend/prisma/migrations/20241106093803_add_notification_setting_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "notificationsEnabled" BOOLEAN;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   createdAt             DateTime    @default(now())
   notificationUserId    String?
   notificationUsername  String?
+  notificationsEnabled  Boolean?
   AuthToken             AuthToken[]
   Backup                Backup[]
 }

--- a/apps/backend/src/lib/controller/notification/telegram/client.ts
+++ b/apps/backend/src/lib/controller/notification/telegram/client.ts
@@ -1,6 +1,7 @@
 import { Bot } from "grammy";
 import { iNotificationClient } from "../interfaces";
 import { PrismaClient } from "@prisma/client";
+import { CommandContext, Context } from "grammy";
 
 export class TelegramNotificationClient implements iNotificationClient {
   private bot: Bot | undefined;
@@ -18,49 +19,178 @@ export class TelegramNotificationClient implements iNotificationClient {
     this.bot = new Bot(process.env.TELEGRAM_BOT_API);
   }
 
+  private async register(ctx: CommandContext<Context>): Promise<void> {
+    const telegramUserId = ctx.from?.id;
+    const telegramUsername = ctx.from?.username;
+    const backendUserId = ctx.match;
+
+    try {
+      if (!telegramUserId || !backendUserId) {
+        throw new Error("Invalid user IDs");
+      }
+
+      // Store the association in your database
+      await this.prismaClient.user.update({
+        where: {id: backendUserId},
+        data: {
+          notificationUserId: telegramUserId?.toString(),
+          notificationUsername: telegramUsername,
+          notificationsEnabled: true,
+        },
+      });
+
+      await ctx.reply(
+        `I'm Curtis, the Cursive Connections bot. I'm here to help you discover and deepen your connections.`
+      );
+      await ctx.reply(
+        `If you want to stop Cursive Telegram notifications, enter /stop.`
+      );
+      await ctx.reply(
+        `If you want to resume at any time enter /start.`
+      );
+      await ctx.reply(
+        `If you want to offer feedback and chat with the team enter /feedback.`
+      );
+      return;
+    } catch (error) {
+      await ctx.reply(
+        "Sorry, there was an error linking your account. Please try connecting again from your profile in the app."
+      );
+      console.error("Linking error:", error);
+      return;
+    }
+  }
+
+  private async stop(ctx: CommandContext<Context>): Promise<void> {
+    // The start parameter will be available in ctx.from
+    const telegramUsername = ctx.from?.username;
+
+    if (telegramUsername) {
+      try {
+        // Lookup user by telegram name from database
+        const user = await this.prismaClient.user.findFirst({
+          where: {notificationUsername: telegramUsername},
+        });
+
+        if (!user) {
+          throw new Error("User not registered.")
+        }
+
+        await this.prismaClient.user.update({
+          where: { id: user.id },
+          data: {
+            notificationsEnabled: false,
+          },
+        });
+
+        await ctx.reply(
+          `Done! If you want to enable notifications at any time enter /start.`
+        );
+
+        return;
+      } catch (error) {
+        await ctx.reply(
+          "Sorry, there was an error stopping notifications. You may not be registered yet -- you can register via your profile in the app."
+        );
+        console.error("Error while stopping notifications:", error);
+        return;
+      }
+    }
+    await ctx.reply(
+      `Woah man! We need your Telegram username for us to help.`
+    );
+  }
+
+  private async resume(ctx: CommandContext<Context>): Promise<void> {
+    const telegramUsername = ctx.from?.username;
+
+    if (telegramUsername) {
+      try {
+        // Lookup user by telegram name from database
+        const user = await this.prismaClient.user.findFirst({
+          where: {notificationUsername: telegramUsername},
+        });
+
+        if (!user) {
+          throw new Error("User not registered.")
+        }
+
+        if (user.notificationsEnabled) {
+          await ctx.reply(
+            `Silly goose! Your notifications are already enabled!`
+          );
+          return;
+        }
+
+        await this.prismaClient.user.update({
+          where: { id: user.id },
+          data: {
+            notificationsEnabled: true,
+          },
+        });
+
+        await ctx.reply(
+          `Done! If you want to stop notifications at any time enter /stop.`
+        );
+        return;
+      } catch (error) {
+        await ctx.reply(
+          "Sorry, there was an error resuming notifications. You may not be registered yet -- you can register via your profile in the app."
+        );
+        console.error("Error while stopping notifications:", error);
+        return;
+      }
+    }
+    await ctx.reply(
+      `Woah man! We need your Telegram username for us to help.`
+    );
+  }
+
   private async setupBot(): Promise<void> {
     if (!this.bot) {
       throw new Error("Bot is not initialized");
     }
 
     this.bot.command("start", async (ctx) => {
-      // The start parameter will be available in ctx.match
+      // The start parameter will be available in ctx.match when redirected from profile page
       const startParameter = ctx.match;
 
       if (startParameter) {
-        // This is where you can link the Telegram user with your backend user
-        const telegramUserId = ctx.from?.id;
-        const telegramUsername = ctx.from?.username;
-        const backendUserId = startParameter;
-
-        if (!telegramUserId || !backendUserId) {
-          throw new Error("Invalid user IDs");
-        }
-
-        try {
-          // Store the association in your database
-          await this.prismaClient.user.update({
-            where: { id: backendUserId },
-            data: {
-              notificationUserId: telegramUserId?.toString(),
-              notificationUsername: telegramUsername,
-            },
-          });
-
-          await ctx.reply(
-            `I'm Curtis, the Cursive Connections bot. I'm here to help you discover and deepen your connections.`
-          );
-        } catch (error) {
-          await ctx.reply(
-            "Sorry, there was an error linking your account. Please try connecting again."
-          );
-          console.error("Linking error:", error);
-        }
+        this.register(ctx);
       } else {
-        await ctx.reply(
-          "Welcome! Please register for notifications from your profile page."
-        );
+        this.resume(ctx);
       }
+    });
+
+    this.bot.command("stop", async (ctx) => {
+      this.stop(ctx);
+    });
+
+    this.bot.command("feedback", async (ctx) => {
+      await ctx.reply(
+        `Join the Cursive Support channel and talk with the team!`
+      );
+      await ctx.reply(
+        `https://t.me/+5_LUJlsRFfBmMTUx`
+      );
+    });
+
+    this.bot.command("help", async (ctx) => {
+      await ctx.reply(
+        `/start : register or resume notifications.`
+      );
+      await ctx.reply(
+        `/stop : stop notifications.`
+      );
+      await ctx.reply(
+        `/feedback : chat with the Cursive team.`
+      );
+    })
+
+    this.bot.on("message", async (ctx) => {
+      await ctx.reply(
+        `I don't recognize your command, I am just a notification bot (and connections elephant, obviously).`
+      );
     });
 
     this.bot.start({
@@ -107,6 +237,11 @@ export class TelegramNotificationClient implements iNotificationClient {
 
       if (!user?.notificationUserId) {
         console.error("User not linked to Telegram");
+        return false;
+      }
+
+      if (!user.notificationsEnabled) {
+        console.log("User has disabled notifications.");
         return false;
       }
 

--- a/apps/backend/src/lib/controller/postgres/prisma/user/user.ts
+++ b/apps/backend/src/lib/controller/postgres/prisma/user/user.ts
@@ -101,6 +101,7 @@ PrismaPostgresClient.prototype.CreateUser = async function (
       ...createUser,
       usernameLowercase: createUser.username.toLowerCase(),
       email: createUser.email.toLowerCase(),
+      notificationsEnabled: true,
     },
   });
 

--- a/apps/backend/src/lib/controller/postgres/prisma/user/user.ts
+++ b/apps/backend/src/lib/controller/postgres/prisma/user/user.ts
@@ -101,7 +101,7 @@ PrismaPostgresClient.prototype.CreateUser = async function (
       ...createUser,
       usernameLowercase: createUser.username.toLowerCase(),
       email: createUser.email.toLowerCase(),
-      notificationsEnabled: true,
+      notificationsEnabled: false,
     },
   });
 

--- a/apps/frontend/src/components/icons/Icons.tsx
+++ b/apps/frontend/src/components/icons/Icons.tsx
@@ -334,7 +334,7 @@ export const Icons: Record<string, any> = {
       <path
         d="M6.4 9.28L7.68 12.16L8.96 9.28H10.88L7.68 16L4.48 9.28H6.4Z"
         fill="white"
-        fill-opacity="0.5"
+        fillOpacity="0.5"
       />
     </svg>
   ),


### PR DESCRIPTION
New features: 
- `/stop` command to pause notifications.
- `/start` will be used for both registration and for resuming notifications.
- `/feedback` will be used to link to a support channel. 
- `/help` list all commands 

Example: 
<img width="992" alt="image" src="https://github.com/user-attachments/assets/f7fd7960-8da3-4909-8cb0-d9ca40ea53b3">

*In this example after ran `/stop` I tested that updating the user chip did not send a notification. After running `/start` again I also tested that the notification was correctly sent. 

