### PR TITLE
If User and Session Exist Ensure Unregistered User is Cleaned Up

### DIFF
--- a/apps/frontend/src/lib/storage/localStorage/user/connection/tap.ts
+++ b/apps/frontend/src/lib/storage/localStorage/user/connection/tap.ts
@@ -195,6 +195,10 @@ export const addUserTap = async (
       newBackupData: [connectionBackup, tapActivityBackup],
     });
   } else {
+    // NOTE: This is the *only* place where createUnregisteredUser and saveUnregisteredUser are called.
+    // This is intention to ensure unregistered user is *only* created when a client has no user AND no session
+    // (indicating that they're logged out / accountless)
+
     // If unregistered user does not exist already, initialize it
     if (!unregisteredUser) {
       unregisteredUser = await createUnregisteredUser();

--- a/apps/frontend/src/pages/_app.tsx
+++ b/apps/frontend/src/pages/_app.tsx
@@ -80,6 +80,11 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         }
       }
 
+      if (user && session && unregisteredUser) {
+        // If user and session are active, ensure unregisteredUser is cleaned up
+        await storage.deleteUnregisteredUser();
+      }
+
     }
     gateUnregisteredUser();
   });


### PR DESCRIPTION
Tested full flow of creating a new unregistered user, tapping some folks, and then generating an account. 

This error indicates that unregistered users are being created for existing users. This is odd because unregistered user creation is *only* called if (!user && !session) during a tap flow. 