### PR TITLE
Sanitize Newline Escape Sequence

### DIFF
--- a/apps/frontend/src/lib/exports/index.ts
+++ b/apps/frontend/src/lib/exports/index.ts
@@ -9,7 +9,13 @@ function sanitizeCSVExport(data: string | undefined): string {
     return "";
   }
   data = data.replaceAll(";", ",");
-  return data.replaceAll("\n", " ");
+  data = data.replaceAll("\n", " ");
+  data = data.replaceAll("\b", " ");
+  data = data.replaceAll("\f", " ");
+  data = data.replaceAll("\r", " ");
+  data = data.replaceAll("\t", " ");
+  data = data.replaceAll("\v", " ");
+  return data
 }
 
 function flattenAndEscapeUserData(user: Connection): FlattenedUserData {

--- a/apps/frontend/src/lib/exports/index.ts
+++ b/apps/frontend/src/lib/exports/index.ts
@@ -4,29 +4,30 @@ import { toast } from "sonner";
 
 // NOTE: the CSV delimiter is a semicolon. If a user-inputted value has a semicolon it's swapped out with a comma to
 // prevent the exported CSV from being corrupted
-function swapSemicolons(data: string | undefined): string {
+function sanitizeCSVExport(data: string | undefined): string {
   if (!data) {
     return "";
   }
-  return data.replaceAll(";", ",");
+  data = data.replaceAll(";", ",");
+  return data.replaceAll("\n", " ");
 }
 
 function flattenAndEscapeUserData(user: Connection): FlattenedUserData {
   const userData = user.user;
   const comment = user.comment;
   return {
-    username: swapSemicolons(userData.username),
-    displayName: swapSemicolons(userData.displayName),
+    username: sanitizeCSVExport(userData.username),
+    displayName: sanitizeCSVExport(userData.displayName),
     signaturePublicKey: userData.signaturePublicKey,
     encryptionPublicKey: userData.encryptionPublicKey,
-    twitterHandle: swapSemicolons(userData.twitter?.username),
-    signalHandle: swapSemicolons(userData.signal?.username),
-    instagramHandle: swapSemicolons(userData.instagram?.username),
-    farcasterHandle: swapSemicolons(userData.farcaster?.username),
-    bio: swapSemicolons(userData.bio),
-    pronouns: swapSemicolons(userData.pronouns),
-    note: swapSemicolons(comment?.note),
-    emoji: swapSemicolons(comment?.emoji),
+    twitterHandle: sanitizeCSVExport(userData.twitter?.username),
+    signalHandle: sanitizeCSVExport(userData.signal?.username),
+    instagramHandle: sanitizeCSVExport(userData.instagram?.username),
+    farcasterHandle: sanitizeCSVExport(userData.farcaster?.username),
+    bio: sanitizeCSVExport(userData.bio),
+    pronouns: sanitizeCSVExport(userData.pronouns),
+    note: sanitizeCSVExport(comment?.note),
+    emoji: sanitizeCSVExport(comment?.emoji),
   };
 }
 

--- a/apps/frontend/src/lib/exports/index.ts
+++ b/apps/frontend/src/lib/exports/index.ts
@@ -8,13 +8,20 @@ function sanitizeCSVExport(data: string | undefined): string {
   if (!data) {
     return "";
   }
+  // Delimiter
   data = data.replaceAll(";", ",");
+
+  // Escape Characters
   data = data.replaceAll("\n", " ");
   data = data.replaceAll("\b", " ");
   data = data.replaceAll("\f", " ");
   data = data.replaceAll("\r", " ");
   data = data.replaceAll("\t", " ");
   data = data.replaceAll("\v", " ");
+
+  // Handle comments
+  data = data.replaceAll("#", " ");
+
   return data
 }
 


### PR DESCRIPTION
I sanitized: 
- escape sequences^1
- comments in csv^2
- special characters in csv^3

When it came down to it only newline characters (`\n`) messed up exports, I wasn't able to intentionally mess up the exports by using other escape sequences (e.g. `\r`, `\t`), comment (e.g. `#`), and special characters (e.g. `,` , `"`, `\`)  

This works for all my contacts but we could identify other missing edge cases that are outside the set of my ~190 connections. 

Sources: 
1: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape, https://docs.oracle.com/javase/tutorial/java/data/characters.html, https://www.geeksforgeeks.org/what-are-escape-characters-in-javascript/ 
2: https://fastcsv.org/guides/examples/handle-comments/
3: https://support.aodocs.com/hc/en-us/articles/5466301293083-Special-characters-in-CSV-files-for-migrations-from-scratch#-371457883